### PR TITLE
Add freebsd support: Add MAP_FIXED to mmap call.

### DIFF
--- a/src/double_mapped_buffer/unix.rs
+++ b/src/double_mapped_buffer/unix.rs
@@ -89,6 +89,16 @@ impl DoubleMappedBufferImpl {
                 return Err(DoubleMappedBufferError::UnmapSecond);
             }
 
+            #[cfg(target_os = "freebsd")]
+            let buff2 = libc::mmap(
+                buff.add(size),
+                size,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_SHARED | libc::MAP_FIXED,
+                fd,
+                0,
+            );
+            #[cfg(not(target_os = "freebsd"))]
             let buff2 = libc::mmap(
                 buff.add(size),
                 size,


### PR DESCRIPTION
The codeblock fails on freebsd unless MAP_FIXED is explicitly set.