### PR TITLE
fix allocation of large circular buffers on unix: 

### DIFF
--- a/src/double_mapped_buffer/unix.rs
+++ b/src/double_mapped_buffer/unix.rs
@@ -103,7 +103,7 @@ impl DoubleMappedBufferImpl {
                 buff.add(size),
                 size,
                 libc::PROT_READ | libc::PROT_WRITE,
-                libc::MAP_SHARED,
+                libc::MAP_SHARED | libc::MAP_FIXED_NOREPLACE,
                 fd,
                 0,
             );


### PR DESCRIPTION
Add flag to second mmap call of buffer allocation to treat address as a requirement and not as a hint.
Possible failure / fallback is covered by original verification of returned pointer.